### PR TITLE
fix(agent): hand agent-created server files to the container user

### DIFF
--- a/catalyst-agent/Cargo.lock
+++ b/catalyst-agent/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "catalyst-agent"
-version = "1.24.2"
+version = "1.28.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/catalyst-agent/src/file_manager.rs
+++ b/catalyst-agent/src/file_manager.rs
@@ -28,6 +28,13 @@ impl FileManager {
         self.max_file_size.load(Ordering::Relaxed)
     }
 
+    /// The agent data directory. Server directories live at
+    /// `{data_dir}/{server_uuid}`; ownership fixups use this as the boundary
+    /// below which everything is handed to the container user.
+    pub fn data_dir(&self) -> &Path {
+        &self.data_dir
+    }
+
     /// Apply the panel-wide upload cap. Zero is ignored.
     pub fn set_max_file_size(&self, bytes: u64) {
         if bytes == 0 {
@@ -290,6 +297,10 @@ impl FileManager {
             AgentError::FileSystemError(format!("Failed to rename temp file: {}", e))
         })?;
 
+        // The agent runs as root; hand the new file (and any created parents)
+        // to the container user so the server process can modify it (#237).
+        crate::ownership::ensure_container_owned(&self.data_dir, &full_path).await;
+
         info!("File written successfully: {:?}", full_path);
 
         Ok(())
@@ -332,6 +343,10 @@ impl FileManager {
             .await
             .map_err(|e| AgentError::FileSystemError(format!("Failed to rename: {}", e)))?;
 
+        // Rename preserves ownership: if the source was root-owned (legacy
+        // files from #237), re-hand the destination to the container user.
+        crate::ownership::ensure_container_owned(&self.data_dir, &to_path).await;
+
         info!("Renamed successfully: {:?} -> {:?}", from_path, to_path);
 
         Ok(())
@@ -349,6 +364,9 @@ impl FileManager {
             if let Err(e) = fs::create_dir_all(&full_path).await {
                 // Not fatal if it already exists or is a mount point we can read.
                 debug!("create_dir_all for list root {:?}: {}", full_path, e);
+            } else {
+                // Fresh server root: hand it to the container user (#237).
+                crate::ownership::ensure_container_owned(&self.data_dir, &full_path).await;
             }
         }
 
@@ -454,6 +472,9 @@ impl FileManager {
                 })?;
         }
 
+        // Hand the new entry (and created parents) to the container user (#237).
+        crate::ownership::ensure_container_owned(&self.data_dir, &full_path).await;
+
         info!("Entry created: {:?}", full_path);
         Ok(())
     }
@@ -494,6 +515,9 @@ impl FileManager {
         fs::rename(&temp_path, &full_path).await.map_err(|e| {
             AgentError::FileSystemError(format!("Failed to rename temp file: {}", e))
         })?;
+
+        // Hand the uploaded file (and created parents) to the container user (#237).
+        crate::ownership::ensure_container_owned(&self.data_dir, &full_path).await;
 
         info!("File bytes written: {:?} ({} bytes)", full_path, data.len());
         Ok(())
@@ -539,6 +563,10 @@ impl FileManager {
         }
 
         info!("File stream written: {:?} ({} bytes)", full_path, total);
+
+        // Hand the streamed file (and created parents) to the container user (#237).
+        crate::ownership::ensure_container_owned(&self.data_dir, &full_path).await;
+
         Ok(())
     }
 
@@ -579,6 +607,8 @@ impl FileManager {
         fs::create_dir_all(&resolved).await.map_err(|e| {
             AgentError::FileSystemError(format!("Failed to create directory: {}", e))
         })?;
+        // Hand the new directory (and created parents) to the container user (#237).
+        crate::ownership::ensure_container_owned(&self.data_dir, &resolved).await;
         info!("Directory created: {:?}", resolved);
         Ok(())
     }
@@ -719,6 +749,14 @@ impl FileManager {
         // pointing outside the server directory (e.g., to /etc/cron.d).
         self.validate_extracted_symlinks(&target_full, server_id)
             .await?;
+
+        // Extraction runs as root: hand the whole tree to the container user (#237).
+        if let Err(e) = crate::ownership::chown_tree(&target_full).await {
+            warn!(
+                "Failed to hand extracted archive to the container user: {}",
+                e
+            );
+        }
 
         info!(
             "Archive decompressed: {:?} -> {:?}",

--- a/catalyst-agent/src/file_tunnel.rs
+++ b/catalyst-agent/src/file_tunnel.rs
@@ -755,6 +755,9 @@ async fn handle_install_url(ctx: &TunnelCtx<'_>, fm: &FileManager, req: &TunnelR
             return;
         }
 
+        // Hand the downloaded file (and created parents) to the container user (#237).
+        crate::ownership::ensure_container_owned(fm.data_dir(), &target_path).await;
+
         send_json_response(ctx, true, None, None).await;
         return;
     }

--- a/catalyst-agent/src/main.rs
+++ b/catalyst-agent/src/main.rs
@@ -19,6 +19,7 @@ mod file_tunnel;
 mod firewall_manager;
 mod net_utils;
 mod network_manager;
+mod ownership;
 mod runtime_manager;
 mod sftp_server;
 mod shell_utils;
@@ -153,6 +154,21 @@ impl CatalystAgent {
             self.ws_handler
                 .queue_startup_error(format!("Storage heal on startup failed: {}", e))
                 .await;
+        }
+
+        // One-time repair for server files created by earlier versions that
+        // left them owned by root (issue #237). Background: chowning a large
+        // tree must not delay startup; new writes are fixed inline from here.
+        {
+            let data_dir = self.config.server.data_dir.clone();
+            let ws = self.ws_handler.clone();
+            tokio::spawn(async move {
+                if let Err(e) = crate::ownership::repair_existing_servers(&data_dir).await {
+                    warn!("Ownership repair on startup failed: {}", e);
+                    ws.queue_startup_error(format!("Ownership repair on startup failed: {}", e))
+                        .await;
+                }
+            });
         }
 
         // Run an initial resource snapshot immediately (captures current usage at startup)

--- a/catalyst-agent/src/ownership.rs
+++ b/catalyst-agent/src/ownership.rs
@@ -1,0 +1,271 @@
+//! Ownership fixups for server data files.
+//!
+//! The agent runs as root (it must, to manage containerd, mounts, and the
+//! firewall), but server containers run as `uid/gid 1000` and their `/data`
+//! is a bind mount of `{data_dir}/{server_uuid}`. Any file or directory the
+//! agent creates inside a server's data directory is initially owned by
+//! `root:root`, which the container process cannot modify — installers and
+//! game servers then fail to write their own files (issue #237).
+//!
+//! Every agent-side creation path under a server directory must therefore
+//! hand the created file (and any directories it had to create) to the
+//! container user. The helpers here centralize that policy. They are
+//! best-effort: the underlying operation has already succeeded, so failures
+//! are logged rather than propagated. When the agent is not running as root
+//! (e.g. local development) the chown syscall cannot succeed and is skipped.
+
+use std::path::{Path, PathBuf};
+use tracing::{debug, info, warn};
+
+/// UID the server containers run as (matches the runtime spec in
+/// `runtime_manager::image_and_spec` and the install wrapper in
+/// `runtime_manager::container_ops`, which both use 1000).
+pub const CONTAINER_UID: u32 = 1000;
+/// GID the server containers run as.
+pub const CONTAINER_GID: u32 = 1000;
+
+/// Agent-owned state under the data dir. Everything else (a server's data
+/// dir is `{data_dir}/{server_uuid}`) is container data and must be owned by
+/// the container user.
+const DATA_DIR_AGENT_ENTRIES: &[&str] = &["images", "backups", "migrate", "console"];
+
+/// True when the current process can change file ownership (i.e. is root).
+pub fn can_chown() -> bool {
+    // SAFETY: geteuid() is a simple syscall that always succeeds.
+    unsafe { libc::geteuid() == 0 }
+}
+
+/// Walk from `path` up to (excluding) `stop_at` and return every ancestor in
+/// between, innermost first. Returns an empty vec when `path` equals or lies
+/// outside `stop_at`.
+fn ancestors_below(stop_at: &Path, path: &Path) -> Vec<PathBuf> {
+    let stop = stop_at
+        .canonicalize()
+        .unwrap_or_else(|_| stop_at.to_path_buf());
+    let mut out = Vec::new();
+    let mut current = Some(path);
+    while let Some(p) = current {
+        if !p.starts_with(&stop) || p == stop {
+            break;
+        }
+        out.push(p.to_path_buf());
+        current = p.parent();
+    }
+    out
+}
+
+/// chown a single path to the container user. Best-effort: a missing path is
+/// silently ignored (the caller may chown before the file exists), anything
+/// else is logged.
+async fn chown_one(path: &Path) {
+    match std::os::unix::fs::chown(path, Some(CONTAINER_UID), Some(CONTAINER_GID)) {
+        Ok(()) => debug!(
+            "Handed {:?} to the container user ({}:{})",
+            path, CONTAINER_UID, CONTAINER_GID
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => warn!(
+            "Could not hand {:?} to the container user ({}:{}): {}",
+            path, CONTAINER_UID, CONTAINER_GID, e
+        ),
+    }
+}
+
+/// Hand `path` — and every ancestor directory strictly below `stop_at` — to
+/// the container user. Callers pass the agent data dir as `stop_at` so any
+/// directories the agent had to create between the server root and the file
+/// are covered too. Best-effort; no-op when not running as root.
+pub async fn ensure_container_owned(stop_at: &Path, path: &Path) {
+    if !can_chown() {
+        return;
+    }
+    for p in ancestors_below(stop_at, path) {
+        chown_one(&p).await;
+    }
+}
+
+/// Recursively hand `dir` and everything below it to the container user.
+/// Used after bulk operations (archive extraction, restore, clone) that
+/// create whole trees. Best-effort; no-op when not running as root.
+pub async fn chown_tree(dir: &Path) -> std::io::Result<()> {
+    if !can_chown() {
+        return Ok(());
+    }
+    let status = tokio::process::Command::new("chown")
+        .arg("-R")
+        .arg(format!("{}:{}", CONTAINER_UID, CONTAINER_GID))
+        .arg(dir)
+        .status()
+        .await?;
+    if !status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "chown -R {}:{} failed with exit code {:?}",
+                CONTAINER_UID,
+                CONTAINER_GID,
+                status.code()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// One-time repair for server directories created or written by earlier
+/// agent versions, which left files owned by `root:root` (issue #237).
+/// Chowns every directory under the data dir that is not agent-owned state
+/// (see [`DATA_DIR_AGENT_ENTRIES`]) to the container user. Called in the
+/// background on agent startup; safe to re-run (chown is idempotent).
+pub async fn repair_existing_servers(data_dir: &Path) -> std::io::Result<usize> {
+    if !can_chown() {
+        return Ok(0);
+    }
+    let mut repaired = 0;
+    let mut entries = tokio::fs::read_dir(data_dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if DATA_DIR_AGENT_ENTRIES.iter().any(|s| *s == name) {
+            continue;
+        }
+        let path = entry.path();
+        // Only directories can be server data dirs; symlink_metadata does not
+        // follow symlinks, so a symlink planted in the data dir can never make
+        // the recursive chown below walk outside the data dir.
+        match tokio::fs::symlink_metadata(&path).await {
+            Ok(m) if m.is_dir() => {}
+            _ => continue,
+        }
+        // Server dirs are single safe path segments (uuids); skip anything else.
+        if crate::shell_utils::validate_safe_path_segment(&name, "data dir entry").is_err() {
+            continue;
+        }
+        match chown_tree(&path).await {
+            Ok(()) => repaired += 1,
+            Err(e) => warn!("Ownership repair failed for {:?}: {}", path, e),
+        }
+    }
+    if repaired > 0 {
+        info!(
+            "Ownership repair: handed {} server director{} to the container user ({}:{})",
+            repaired,
+            if repaired == 1 { "y" } else { "ies" },
+            CONTAINER_UID,
+            CONTAINER_GID
+        );
+    }
+    Ok(repaired)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// chown to another uid requires root; only assert ownership when the
+    /// test process can actually change it.
+    fn ownership_observable() -> bool {
+        can_chown()
+    }
+
+    #[test]
+    fn ancestors_below_walks_innermost_first() {
+        let stop = Path::new("/data");
+        let file = Path::new("/data/srv1/a/b/file.txt");
+        let got = ancestors_below(stop, file);
+        let parts: Vec<&str> = got.iter().map(|p| p.to_str().unwrap()).collect();
+        assert_eq!(
+            parts,
+            vec![
+                "/data/srv1/a/b/file.txt",
+                "/data/srv1/a/b",
+                "/data/srv1/a",
+                "/data/srv1"
+            ]
+        );
+    }
+
+    #[test]
+    fn ancestors_below_stops_at_boundary() {
+        assert!(ancestors_below(Path::new("/data"), Path::new("/data")).is_empty());
+        assert!(ancestors_below(Path::new("/data"), Path::new("/etc/passwd")).is_empty());
+        assert!(ancestors_below(Path::new("/data"), Path::new("/database/x")).is_empty());
+    }
+
+    #[test]
+    fn ancestors_below_keeps_sibling_prefixes_out() {
+        // "/datax" must not count as below "/data".
+        assert!(ancestors_below(Path::new("/data"), Path::new("/datax/srv1")).is_empty());
+    }
+
+    #[tokio::test]
+    async fn ensure_container_owned_sets_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("srv1").join("sub");
+        std::fs::create_dir_all(&nested).unwrap();
+        let file = nested.join("f.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        ensure_container_owned(dir.path(), &file).await;
+
+        if !ownership_observable() {
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+        for p in [&file, &nested, &dir.path().join("srv1")] {
+            let meta = std::fs::metadata(p).unwrap();
+            assert_eq!(meta.uid(), CONTAINER_UID, "uid of {:?}", p);
+            assert_eq!(meta.gid(), CONTAINER_GID, "gid of {:?}", p);
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_container_owned_tolerates_missing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        // Leaf does not exist yet — must not warn/panic, ancestors still fixed.
+        ensure_container_owned(dir.path(), &dir.path().join("later.txt")).await;
+    }
+
+    #[tokio::test]
+    async fn chown_tree_sets_owner_recursively() {
+        let dir = tempfile::tempdir().unwrap();
+        let tree = dir.path().join("srv1");
+        std::fs::create_dir_all(tree.join("a")).unwrap();
+        std::fs::write(tree.join("a").join("f.bin"), b"x").unwrap();
+
+        chown_tree(&tree).await.unwrap();
+
+        if !ownership_observable() {
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(tree.join("a").join("f.bin")).unwrap();
+        assert_eq!(meta.uid(), CONTAINER_UID);
+        assert_eq!(meta.gid(), CONTAINER_GID);
+    }
+
+    #[tokio::test]
+    async fn repair_existing_servers_fixes_server_dirs_only() {
+        let data = tempfile::tempdir().unwrap();
+        // Server data dir (uuid-like name) plus agent-owned state that must
+        // be skipped, and a non-server file.
+        let server = data.path().join("cmaid8f9x0001uvqx9abcd123");
+        std::fs::create_dir_all(server.join("plugins")).unwrap();
+        std::fs::write(server.join("server.properties"), b"x").unwrap();
+        std::fs::create_dir_all(data.path().join("images")).unwrap();
+        std::fs::write(data.path().join("images").join("keep.img"), b"").unwrap();
+        std::fs::write(data.path().join("firewall-rules.jsonl"), b"").unwrap();
+
+        let repaired = repair_existing_servers(data.path()).await.unwrap();
+
+        // Exactly one directory is a repairable server dir: the exclusion
+        // list must have skipped `images`, and the loose file never counts.
+        assert_eq!(repaired, if ownership_observable() { 1 } else { 0 });
+
+        if !ownership_observable() {
+            return;
+        }
+        use std::os::unix::fs::MetadataExt;
+        let meta = std::fs::metadata(server.join("server.properties")).unwrap();
+        assert_eq!(meta.uid(), CONTAINER_UID);
+        assert_eq!(meta.gid(), CONTAINER_GID);
+    }
+}

--- a/catalyst-agent/src/sftp_server.rs
+++ b/catalyst-agent/src/sftp_server.rs
@@ -507,6 +507,10 @@ impl russh_sftp::server::Handler for CatalystSftpHandler {
                 }
             })?;
 
+            // SFTP writes bypass FileManager, so ownership is fixed here:
+            // hand the file (and created parents) to the container user (#237).
+            crate::ownership::ensure_container_owned(fm.data_dir(), &full_path).await;
+
             Ok(Self::status_ok(id))
         }
     }

--- a/catalyst-agent/src/websocket_handler/mod.rs
+++ b/catalyst-agent/src/websocket_handler/mod.rs
@@ -35,8 +35,7 @@ pub(crate) type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 pub(crate) type WsWrite = SplitSink<WsStream, Message>;
 pub(crate) const CONTAINER_SERVER_DIR: &str = "/data";
-pub(crate) const CONTAINER_UID: u32 = 1000;
-pub(crate) const CONTAINER_GID: u32 = 1000;
+pub(crate) use crate::ownership::chown_tree as chown_to_container_user;
 pub(crate) const MAX_BACKUP_UPLOAD_BYTES: u64 = 10 * 1024 * 1024 * 1024; // 10GB
 pub(crate) const MAX_RESTORE_STREAM_BYTES: u64 = 10 * 1024 * 1024 * 1024; // 10 GB, matches MAX_BACKUP_UPLOAD_BYTES
 pub(crate) const BACKUP_UPLOAD_INACTIVITY_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
@@ -411,25 +410,6 @@ pub(crate) fn parse_auto_restart_config(msg: &Value) -> AutoRestartConfig {
         .and_then(Value::as_u64)
         .unwrap_or(config.window_secs);
     config
-}
-
-/// Set ownership of a directory to the container user (uid 1000:gid 1000)
-/// so the game server process can read/write its data.
-pub(crate) async fn chown_to_container_user(dir: &std::path::Path) -> std::io::Result<()> {
-    use tokio::process::Command;
-    let status = Command::new("chown")
-        .arg("-R")
-        .arg(format!("{}:{}", CONTAINER_UID, CONTAINER_GID))
-        .arg(dir)
-        .status()
-        .await?;
-    if !status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            format!("chown failed with exit code {:?}", status.code()),
-        ));
-    }
-    Ok(())
 }
 
 pub struct WebSocketHandler {
@@ -3157,6 +3137,9 @@ impl WebSocketHandler {
             )
             .await
             .map_err(|e| AgentError::IoError(format!("Failed to write eula.txt: {}", e)))?;
+            // The container process owns eula.txt at runtime — hand it over (#237).
+            crate::ownership::ensure_container_owned(&self.config.server.data_dir, &eula_file)
+                .await;
 
             info!("EULA accepted for server {}", server_uuid);
             self.emit_console_output(


### PR DESCRIPTION
Fixes #237

## Problem

The agent runs as root (it must, to manage containerd, mounts, and the firewall), but server containers run as `uid/gid 1000` with `/data` bind-mounted from `{data_dir}/{server_uuid}`. Every file the agent created inside a server's data directory ended up owned by `root:root`:

- web file manager: editor saves, new files, uploads
- SFTP: file writes and created directories
- installs via URL (`install-url` tunnel op)
- archive extraction (decompress in file manager)
- `eula.txt` written on EULA accept

The container process (uid 1000) then could not modify its own files, so installers and game servers failed until an admin ran `chown -R` by hand. Backup restore and file clone already fixed ownership afterwards — the other creation paths never did.

## Fix

New `catalyst-agent/src/ownership.rs` centralizes the policy:

- `ensure_container_owned(data_dir, path)` — hands a created file **and every ancestor directory it created** below the data dir to `1000:1000` (a fresh `plugins/Essentials/config.yml` fixes the two new dirs too, not just the file).
- `chown_tree(dir)` — recursive chown for bulk operations; replaces the old inline `chown_to_container_user` helper (same behavior, now shared).
- `repair_existing_servers(data_dir)` — one-time background repair on agent startup that chowns existing server directories (any data-dir entry that is not agent-owned state: `images`, `backups`, `migrate`, `console`) so nodes already hit by the bug heal themselves after updating. Entries are validated as single safe path segments and symlinks are never followed.

Applied on every creation path: `write_file`, `create_entry`, `write_file_bytes`, `write_file_stream`, `mkdir`, `rename_file` (rename preserves the source's ownership, so a root-owned legacy file stays root-owned after rename — now fixed), `decompress_to`, the SFTP raw `write` handler (bypasses FileManager), tunnel `install-url` downloads, and the EULA accept write.

All chowns are best-effort and skipped entirely when the agent does not run as root, so local development is unaffected.

## Verification

- `cargo fmt`, `cargo clippy -D warnings`, and the full agent test suite (115 tests) pass
- Ownership unit tests were additionally run as root so the chown paths are really exercised (as non-root they are skipped by design)
- Reproduced the bug end-to-end outside the crate (root process creates nested file → `0:0`) and confirmed the exact fix logic yields `1000:1000` on the file and all created parents, while paths outside the boundary (`/etc/passwd` probe) are never touched